### PR TITLE
Add matrix support for OS in PyInstaller build job

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   pyinstaller-build:
-    runs-on: #<windows-latest / ubuntu-latest / ..... etc>
+    matrix:
+      os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - name: Create Executable
         uses: sayyid5416/pyinstaller@v1
@@ -19,5 +20,5 @@ jobs:
           requirements: "requirements.txt"
           upload_exe_with_name: "My executable"
           options: --onefile --noconsole --strip --clean --name OCISessionManager --add-data "resources;resources" --icon "resources/green_icon.ico"
-          spec_options: # any custom arguments you want like: `--debug`
+          # spec_options: # any custom arguments you want like: `--debug`
 


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/build-and-release.yaml` file to enhance the build and release process by adding support for multiple operating systems and cleaning up unnecessary comments.

Enhancements to build and release process:

* [`.github/workflows/build-and-release.yaml`](diffhunk://#diff-ad4426c4339c88e5a644696af58c8c29aa5ff4401faf486584641e1a542dff44L11-R12): Updated the `runs-on` configuration to use a matrix strategy, adding support for `windows-latest`, `ubuntu-latest`, and `macos-latest` operating systems.
* [`.github/workflows/build-and-release.yaml`](diffhunk://#diff-ad4426c4339c88e5a644696af58c8c29aa5ff4401faf486584641e1a542dff44L22-R23): Commented out the `spec_options` line to clean up the file, as it was not being used.